### PR TITLE
fix(client): Add full list of spdx licenses. Closes #131

### DIFF
--- a/lib/spdx-license-list.js
+++ b/lib/spdx-license-list.js
@@ -1,398 +1,1478 @@
 module.exports = {
-  'Apache-1.1': {
-    'name': 'Apache License 1.1',
-    'url':  'http://apache.org/licenses/LICENSE-1.1',
-  },
-  'Artistic-1.0-Perl': {
-    'name': 'Artistic License 1.0 (Perl)',
-    'url':  'http://dev.perl.org/licenses/artistic.html',
-  },
-  'AGPL-3.0-only': {
-    'name': 'GNU Affero General Public License v3.0 only',
-    'url':  'http://www.gnu.org/licenses/agpl.txt',
-  },
-  'CECILL-2.1': {
-    'name': 'CeCILL Free Software License Agreement v2.1',
-    'url':  'http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html',
-  },
-  'EFL-1.0': {
-    'name': 'Eiffel Forum License v1.0',
-    'url':  'http://www.eiffel-nice.org/license/forum.txt',
-  },
-  'EFL-2.0': {
-    'name': 'Eiffel Forum License v2.0',
-    'url':  'http://www.eiffel-nice.org/license/eiffel-forum-license-2.html',
-  },
-  'AGPL-3.0-or-later': {
-    'name': 'GNU Affero General Public License v3.0 or later',
-    'url':  'http://www.gnu.org/licenses/agpl.txt',
-  },
-  'Apache-2.0': {
-    'name': 'Apache License 2.0',
-    'url':  'http://www.apache.org/licenses/LICENSE-2.0',
-  },
-  'GPL-2.0-only': {
-    'name': 'GNU General Public License v2.0 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html',
-  },
-  'EPL-1.0': {
-    'name': 'Eclipse Public License 1.0',
-    'url':  'http://www.eclipse.org/legal/epl-v10.html',
-  },
-  'GPL-3.0-only': {
-    'name': 'GNU General Public License v3.0 only',
-    'url':  'http://www.gnu.org/licenses/gpl-3.0-standalone.html',
-  },
-  'GPL-2.0-or-later': {
-    'name': 'GNU General Public License v2.0 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html',
-  },
-  'GPL-3.0-or-later': {
-    'name': 'GNU General Public License v3.0 or later',
-    'url':  'http://www.gnu.org/licenses/gpl-3.0-standalone.html',
-  },
-  'LGPL-2.0-or-later': {
-    'name': 'GNU Library General Public License v2 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html',
-  },
-  'LGPL-2.0-only': {
-    'name': 'GNU Library General Public License v2 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html',
-  },
-  'LGPL-2.1-only': {
-    'name': 'GNU Lesser General Public License v2.1 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html',
-  },
-  'BSD-2-Clause-Patent': {
-    'name': 'BSD-2-Clause Plus Patent License',
-    'url':  'https://opensource.org/licenses/BSDplusPatent',
-  },
-  'LGPL-3.0-or-later': {
-    'name': 'GNU Lesser General Public License v3.0 or later',
-    'url':  'http://www.gnu.org/licenses/lgpl-3.0-standalone.html',
-  },
-  'LGPL-2.1-or-later': {
-    'name': 'GNU Lesser General Public License v2.1 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html',
-  },
-  'LGPL-3.0-only': {
-    'name': 'GNU Lesser General Public License v3.0 only',
-    'url':  'http://www.gnu.org/licenses/lgpl-3.0-standalone.html',
-  },
-  'OGTSL': {
-    'name': 'Open Group Test Suite License',
-    'url':  'http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt',
-  },
-  'EUPL-1.2': {
-    'name': 'European Union Public License 1.2',
-    'url':  'https://joinup.ec.europa.eu/page/eupl-text-11-12',
-  },
-  'ZPL-2.0': {
-    'name': 'Zope Public License 2.0',
-    'url':  'http://old.zope.org/Resources/License/ZPL-2.0',
-  },
-  'W3C': {
-    'name': 'W3C Software Notice and License (2002-12-31)',
-    'url':  'http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html',
-  },
-  'AGPL-3.0': {
-    'name': 'GNU Affero General Public License v3.0',
-    'url':  'http://www.gnu.org/licenses/agpl.txt',
-  },
-  'GPL-2.0+': {
-    'name': 'GNU General Public License v2.0 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html',
-  },
-  'GPL-2.0': {
-    'name': 'GNU General Public License v2.0 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html',
-  },
-  'GPL-3.0+': {
-    'name': 'GNU General Public License v3.0 or later',
-    'url':  'http://www.gnu.org/licenses/gpl-3.0-standalone.html',
-  },
-  'GPL-3.0-with-GCC-exception': {
-    'name': 'GNU General Public License v3.0 w/GCC Runtime Library exception',
-    'url':  'http://www.gnu.org/licenses/gcc-exception-3.1.html',
-  },
-  'LGPL-2.0+': {
-    'name': 'GNU Library General Public License v2 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html',
-  },
-  'GPL-3.0': {
-    'name': 'GNU General Public License v3.0 only',
-    'url':  'http://www.gnu.org/licenses/gpl-3.0-standalone.html',
-  },
-  'LGPL-2.0': {
-    'name': 'GNU Library General Public License v2 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html',
-  },
-  'LGPL-3.0+': {
-    'name': 'GNU Lesser General Public License v3.0 or later',
-    'url':  'http://www.gnu.org/licenses/lgpl-3.0-standalone.html',
-  },
-  'LGPL-2.1': {
-    'name': 'GNU Lesser General Public License v2.1 only',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html',
-  },
-  'LGPL-2.1+': {
-    'name': 'GNU Library General Public License v2 or later',
-    'url':  'http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html',
-  },
-  'LGPL-3.0': {
-    'name': 'GNU Lesser General Public License v3.0 only',
-    'url':  'http://www.gnu.org/licenses/lgpl-3.0-standalone.html',
-  },
-  'SISSL': {
-    'name': 'Sun Industry Standards Source License v1.1',
-    'url':  'http://www.openoffice.org/licenses/sissl_license.html',
-  },
-  'LPPL-1.3c': {
-    'name': 'LaTeX Project Public License v1.3c',
-    'url':  'http://www.latex-project.org/lppl/lppl-1-3c.txt',
-  },
-  'Zlib': {
-    'name': 'zlib License',
-    'url':  'http://www.zlib.net/zlib_license.html',
-  },
-  'EUPL-1.1': {
-    'name': 'European Union Public License 1.1',
-    'url':  'https://joinup.ec.europa.eu/software/page/eupl/licence-eupl',
-  },
-  'APSL-1.1': {
-    'name': 'Apple Public Source License 1.1',
-    'url':  'http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE',
-  },
-  'ISC': {
-    'name': 'ISC License',
-    'url':  'https://www.isc.org/downloads/software-support-policy/isc-license/',
-  },
-  'Artistic-2.0': {
-    'name': 'Artistic License 2.0',
-    'url':  'http://www.perlfoundation.org/artistic_license_2_0',
-  },
-  'MPL-2.0-no-copyleft-exception': {
-    'name': 'Mozilla Public License 2.0 (no copyleft exception)',
-    'url':  'http://www.mozilla.org/MPL/2.0/',
-  },
-  'MPL-2.0': {
-    'name': 'Mozilla Public License 2.0',
-    'url':  'http://www.mozilla.org/MPL/2.0/',
-  },
-  'LPL-1.0': {
-    'name': 'Lucent Public License Version 1.0',
-    'url':  'http://opensource.org/licenses/LPL-1.0',
-  },
-  'LiLiQ-P-1.1': {
-    'name': 'Licence Libre du Québec – Permissive version 1.1',
-    'url':  'http://opensource.org/licenses/LiLiQ-P-1.1',
-  },
-  'LiLiQ-R-1.1': {
-    'name': 'Licence Libre du Québec – Réciprocité version 1.1',
-    'url':  'http://opensource.org/licenses/LiLiQ-R-1.1',
-  },
-  'LiLiQ-Rplus-1.1': {
-    'name': 'Licence Libre du Québec – Réciprocité forte version 1.1',
-    'url':  'http://opensource.org/licenses/LiLiQ-Rplus-1.1',
-  },
-  'Intel': {
-    'name': 'Intel Open Source License',
-    'url':  'http://opensource.org/licenses/Intel',
-  },
-  'CATOSL-1.1': {
-    'name': 'Computer Associates Trusted Open Source License 1.1',
-    'url':  'http://opensource.org/licenses/CATOSL-1.1',
-  },
-  'ECL-1.0': {
-    'name': 'Educational Community License v1.0',
-    'url':  'http://opensource.org/licenses/ECL-1.0',
-  },
-  'APSL-1.0': {
-    'name': 'Apple Public Source License 1.0',
-    'url':  'https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0',
-  },
-  'CUA-OPL-1.0': {
-    'name': 'CUA Office Public License v1.0',
-    'url':  'http://opensource.org/licenses/CUA-OPL-1.0',
-  },
-  'MPL-1.1': {
-    'name': 'Mozilla Public License 1.1',
-    'url':  'http://www.mozilla.org/MPL/MPL-1.1.html',
-  },
-  'OSL-2.0': {
-    'name': 'Open Software License 2.0',
-    'url':  'http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html',
-  },
-  'Artistic-1.0': {
-    'name': 'Artistic License 1.0',
-    'url':  'http://opensource.org/licenses/Artistic-1.0',
-  },
-  'Artistic-1.0-cl8': {
-    'name': 'Artistic License 1.0 w/clause 8',
-    'url':  'http://opensource.org/licenses/Artistic-1.0',
-  },
-  'Entessa': {
-    'name': 'Entessa Public License v1.0',
-    'url':  'http://opensource.org/licenses/Entessa',
-  },
-  'OSET-PL-2.1': {
-    'name': 'OSET Public License version 2.1',
-    'url':  'http://opensource.org/licenses/OPL-2.1',
-  },
-  'ECL-2.0': {
-    'name': 'Educational Community License v2.0',
-    'url':  'http://opensource.org/licenses/ECL-2.0',
-  },
-  'UPL-1.0': {
-    'name': 'Universal Permissive License v1.0',
-    'url':  'http://opensource.org/licenses/UPL',
-  },
-  'BSL-1.0': {
-    'name': 'Boost Software License 1.0',
-    'url':  'http://www.boost.org/LICENSE_1_0.txt',
-  },
-  'OSL-2.1': {
-    'name': 'Open Software License 2.1',
-    'url':  'http://opensource.org/licenses/OSL-2.1',
-  },
-  'CPL-1.0': {
-    'name': 'Common Public License 1.0',
-    'url':  'http://opensource.org/licenses/CPL-1.0',
-  },
-  'RPL-1.1': {
-    'name': 'Reciprocal Public License 1.1',
-    'url':  'http://opensource.org/licenses/RPL-1.1',
-  },
-  'OSL-1.0': {
-    'name': 'Open Software License 1.0',
-    'url':  'http://opensource.org/licenses/OSL-1.0',
-  },
-  'AAL': {
-    'name': 'Attribution Assurance License',
-    'url':  'http://www.opensource.org/licenses/attribution',
-  },
-  'APL-1.0': {
-    'name': 'Adaptive Public License 1.0',
-    'url':  'http://www.opensource.org/licenses/APL-1.0',
-  },
-  'BSD-2-Clause': {
-    'name': 'BSD 2-Clause "Simplified" License',
-    'url':  'http://www.opensource.org/licenses/BSD-2-Clause',
-  },
-  'BSD-3-Clause': {
-    'name': 'BSD 3-Clause "New" or "Revised" License',
-    'url':  'http://www.opensource.org/licenses/BSD-3-Clause',
-  },
-  'CDDL-1.0': {
-    'name': 'Common Development and Distribution License 1.0',
-    'url':  'http://www.opensource.org/licenses/cddl1',
-  },
-  'CPAL-1.0': {
-    'name': 'Common Public Attribution License 1.0',
-    'url':  'http://www.opensource.org/licenses/CPAL-1.0',
-  },
-  'Frameworx-1.0': {
-    'name': 'Frameworx Open License 1.0',
-    'url':  'http://www.opensource.org/licenses/Frameworx-1.0',
-  },
-  'CNRI-Python': {
-    'name': 'CNRI Python License',
-    'url':  'http://www.opensource.org/licenses/CNRI-Python',
-  },
-  'MIT': {
-    'name': 'MIT License',
-    'url':  'http://www.opensource.org/licenses/MIT',
-  },
-  'HPND': {
-    'name': 'Historical Permission Notice and Disclaimer',
-    'url':  'http://www.opensource.org/licenses/HPND',
-  },
-  'Fair': {
-    'name': 'Fair License',
-    'url':  'http://www.opensource.org/licenses/Fair',
-  },
-  'NPOSL-3.0': {
-    'name': 'Non-Profit Open Software License 3.0',
-    'url':  'http://www.opensource.org/licenses/NOSL3.0',
-  },
-  'IPL-1.0': {
-    'name': 'IBM Public License v1.0',
-    'url':  'http://www.opensource.org/licenses/IPL-1.0',
-  },
-  'Multics': {
-    'name': 'Multics License',
-    'url':  'http://www.opensource.org/licenses/Multics',
-  },
-  'Nokia': {
-    'name': 'Nokia Open Source License',
-    'url':  'http://www.opensource.org/licenses/nokia',
-  },
-  'IPA': {
-    'name': 'IPA Font License',
-    'url':  'http://www.opensource.org/licenses/IPA',
-  },
-  'Motosoto': {
-    'name': 'Motosoto License',
-    'url':  'http://www.opensource.org/licenses/Motosoto',
-  },
-  'MirOS': {
-    'name': 'MirOS License',
-    'url':  'http://www.opensource.org/licenses/MirOS',
-  },
-  'Python-2.0': {
-    'name': 'Python License 2.0',
-    'url':  'http://www.opensource.org/licenses/Python-2.0',
-  },
-  'RPL-1.5': {
-    'name': 'Reciprocal Public License 1.5',
-    'url':  'http://www.opensource.org/licenses/RPL-1.5',
-  },
-  'EPL-2.0': {
-    'name': 'Eclipse Public License 2.0',
-    'url':  'https://www.eclipse.org/legal/epl-2.0',
-  },
-  'Naumen': {
-    'name': 'Naumen Public License',
-    'url':  'http://www.opensource.org/licenses/Naumen',
-  },
-  'NGPL': {
-    'name': 'Nethack General Public License',
-    'url':  'http://www.opensource.org/licenses/NGPL',
-  },
-  'VSL-1.0': {
-    'name': 'Vovida Software License v1.0',
-    'url':  'http://www.opensource.org/licenses/VSL-1.0',
-  },
-  'NTP': {
-    'name': 'NTP License',
-    'url':  'http://www.opensource.org/licenses/NTP',
-  },
-  'RSCPL': {
-    'name': 'Ricoh Source Code Public License',
-    'url':  'http://www.opensource.org/licenses/RSCPL',
-  },
-  'SPL-1.0': {
-    'name': 'Sun Public License v1.0',
-    'url':  'http://www.opensource.org/licenses/SPL-1.0',
-  },
-  'SimPL-2.0': {
-    'name': 'Simple Public License 2.0',
-    'url':  'http://www.opensource.org/licenses/SimPL-2.0',
-  },
-  'Sleepycat': {
-    'name': 'Sleepycat License',
-    'url':  'http://www.opensource.org/licenses/Sleepycat',
-  },
-  'Watcom-1.0': {
-    'name': 'Sybase Open Watcom Public License 1.0',
-    'url':  'http://www.opensource.org/licenses/Watcom-1.0',
-  },
-  'NASA-1.3': {
-    'name': 'NASA Open Source Agreement 1.3',
-    'url':  'http://ti.arc.nasa.gov/opensource/nosa/',
-  },
-  'MPL-1.0': {
-    'name': 'Mozilla Public License 1.0',
-    'url':  'http://www.mozilla.org/MPL/MPL-1.0.html',
-  },
-}
+	"0BSD": {
+		"name": "BSD Zero Clause License",
+		"url": "http://landley.net/toybox/license.html"
+	},
+	"AAL": {
+		"name": "Attribution Assurance License",
+		"url": "http://www.opensource.org/licenses/attribution"
+	},
+	"Abstyles": {
+		"name": "Abstyles License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Abstyles"
+	},
+	"Adobe-2006": {
+		"name": "Adobe Systems Incorporated Source Code License Agreement",
+		"url": "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+	},
+	"Adobe-Glyph": {
+		"name": "Adobe Glyph List License",
+		"url": "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+	},
+	"ADSL": {
+		"name": "Amazon Digital Services License",
+		"url": "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+	},
+	"AFL-1.1": {
+		"name": "Academic Free License v1.1",
+		"url": "http://opensource.linux-mirror.org/licenses/afl-1.1.txt"
+	},
+	"AFL-1.2": {
+		"name": "Academic Free License v1.2",
+		"url": "http://opensource.linux-mirror.org/licenses/afl-1.2.txt"
+	},
+	"AFL-2.0": {
+		"name": "Academic Free License v2.0",
+		"url": "http://opensource.linux-mirror.org/licenses/afl-2.0.txt"
+	},
+	"AFL-2.1": {
+		"name": "Academic Free License v2.1",
+		"url": "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+	},
+	"AFL-3.0": {
+		"name": "Academic Free License v3.0",
+		"url": "http://www.rosenlaw.com/AFL3.0.htm"
+	},
+	"Afmparse": {
+		"name": "Afmparse License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Afmparse"
+	},
+	"AGPL-1.0": {
+		"name": "Affero General Public License v1.0",
+		"url": "http://www.affero.org/oagpl.html"
+	},
+	"AGPL-3.0-only": {
+		"name": "GNU Affero General Public License v3.0 only",
+		"url": "http://www.gnu.org/licenses/agpl.txt"
+	},
+	"AGPL-3.0-or-later": {
+		"name": "GNU Affero General Public License v3.0 or later",
+		"url": "http://www.gnu.org/licenses/agpl.txt"
+	},
+	"Aladdin": {
+		"name": "Aladdin Free Public License",
+		"url": "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+	},
+	"AMDPLPA": {
+		"name": "AMD's plpa_map.c License",
+		"url": "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+	},
+	"AML": {
+		"name": "Apple MIT License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
+	},
+	"AMPAS": {
+		"name": "Academy of Motion Picture Arts and Sciences BSD",
+		"url": "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+	},
+	"ANTLR-PD": {
+		"name": "ANTLR Software Rights Notice",
+		"url": "http://www.antlr2.org/license.html"
+	},
+	"Apache-1.0": {
+		"name": "Apache License 1.0",
+		"url": "http://www.apache.org/licenses/LICENSE-1.0"
+	},
+	"Apache-1.1": {
+		"name": "Apache License 1.1",
+		"url": "http://apache.org/licenses/LICENSE-1.1"
+	},
+	"Apache-2.0": {
+		"name": "Apache License 2.0",
+		"url": "http://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"APAFML": {
+		"name": "Adobe Postscript AFM License",
+		"url": "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+	},
+	"APL-1.0": {
+		"name": "Adaptive Public License 1.0",
+		"url": "http://www.opensource.org/licenses/APL-1.0"
+	},
+	"APSL-1.0": {
+		"name": "Apple Public Source License 1.0",
+		"url": "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+	},
+	"APSL-1.1": {
+		"name": "Apple Public Source License 1.1",
+		"url": "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+	},
+	"APSL-1.2": {
+		"name": "Apple Public Source License 1.2",
+		"url": "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+	},
+	"APSL-2.0": {
+		"name": "Apple Public Source License 2.0",
+		"url": "http://www.opensource.apple.com/license/apsl/"
+	},
+	"Artistic-1.0-cl8": {
+		"name": "Artistic License 1.0 w/clause 8",
+		"url": "http://opensource.org/licenses/Artistic-1.0"
+	},
+	"Artistic-1.0-Perl": {
+		"name": "Artistic License 1.0 (Perl)",
+		"url": "http://dev.perl.org/licenses/artistic.html"
+	},
+	"Artistic-1.0": {
+		"name": "Artistic License 1.0",
+		"url": "http://opensource.org/licenses/Artistic-1.0"
+	},
+	"Artistic-2.0": {
+		"name": "Artistic License 2.0",
+		"url": "http://www.perlfoundation.org/artistic_license_2_0"
+	},
+	"Bahyph": {
+		"name": "Bahyph License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Bahyph"
+	},
+	"Barr": {
+		"name": "Barr License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Barr"
+	},
+	"Beerware": {
+		"name": "Beerware License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Beerware"
+	},
+	"BitTorrent-1.0": {
+		"name": "BitTorrent Open Source License v1.0",
+		"url": "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s"
+	},
+	"BitTorrent-1.1": {
+		"name": "BitTorrent Open Source License v1.1",
+		"url": "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+	},
+	"Borceux": {
+		"name": "Borceux license",
+		"url": "https://fedoraproject.org/wiki/Licensing/Borceux"
+	},
+	"BSD-1-Clause": {
+		"name": "BSD 1-Clause License",
+		"url": "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823"
+	},
+	"BSD-2-Clause-FreeBSD": {
+		"name": "BSD 2-Clause FreeBSD License",
+		"url": "http://www.freebsd.org/copyright/freebsd-license.html"
+	},
+	"BSD-2-Clause-NetBSD": {
+		"name": "BSD 2-Clause NetBSD License",
+		"url": "http://www.netbsd.org/about/redistribution.html#default"
+	},
+	"BSD-2-Clause-Patent": {
+		"name": "BSD-2-Clause Plus Patent License",
+		"url": "https://opensource.org/licenses/BSDplusPatent"
+	},
+	"BSD-2-Clause": {
+		"name": "BSD 2-Clause \"Simplified\" License",
+		"url": "http://www.opensource.org/licenses/BSD-2-Clause"
+	},
+	"BSD-3-Clause-Attribution": {
+		"name": "BSD with attribution",
+		"url": "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+	},
+	"BSD-3-Clause-Clear": {
+		"name": "BSD 3-Clause Clear License",
+		"url": "http://labs.metacarta.com/license-explanation.html#license"
+	},
+	"BSD-3-Clause-LBNL": {
+		"name": "Lawrence Berkeley National Labs BSD variant license",
+		"url": "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+	},
+	"BSD-3-Clause-No-Nuclear-License-2014": {
+		"name": "BSD 3-Clause No Nuclear License 2014",
+		"url": "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+	},
+	"BSD-3-Clause-No-Nuclear-License": {
+		"name": "BSD 3-Clause No Nuclear License",
+		"url": "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam=1467140197_43d516ce1776bd08a58235a7785be1cc"
+	},
+	"BSD-3-Clause-No-Nuclear-Warranty": {
+		"name": "BSD 3-Clause No Nuclear Warranty",
+		"url": "https://jogamp.org/git/?p=gluegen.git;a=blob_plain;f=LICENSE.txt"
+	},
+	"BSD-3-Clause": {
+		"name": "BSD 3-Clause \"New\" or \"Revised\" License",
+		"url": "http://www.opensource.org/licenses/BSD-3-Clause"
+	},
+	"BSD-4-Clause-UC": {
+		"name": "BSD-4-Clause (University of California-Specific)",
+		"url": "http://www.freebsd.org/copyright/license.html"
+	},
+	"BSD-4-Clause": {
+		"name": "BSD 4-Clause \"Original\" or \"Old\" License",
+		"url": "http://directory.fsf.org/wiki/License:BSD_4Clause"
+	},
+	"BSD-Protection": {
+		"name": "BSD Protection License",
+		"url": "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+	},
+	"BSD-Source-Code": {
+		"name": "BSD Source Code Attribution",
+		"url": "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+	},
+	"BSL-1.0": {
+		"name": "Boost Software License 1.0",
+		"url": "http://www.boost.org/LICENSE_1_0.txt"
+	},
+	"bzip2-1.0.5": {
+		"name": "bzip2 and libbzip2 License v1.0.5",
+		"url": "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+	},
+	"bzip2-1.0.6": {
+		"name": "bzip2 and libbzip2 License v1.0.6",
+		"url": "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
+	},
+	"Caldera": {
+		"name": "Caldera License",
+		"url": "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+	},
+	"CATOSL-1.1": {
+		"name": "Computer Associates Trusted Open Source License 1.1",
+		"url": "http://opensource.org/licenses/CATOSL-1.1"
+	},
+	"CC-BY-1.0": {
+		"name": "Creative Commons Attribution 1.0",
+		"url": "http://creativecommons.org/licenses/by/1.0/legalcode"
+	},
+	"CC-BY-2.0": {
+		"name": "Creative Commons Attribution 2.0",
+		"url": "http://creativecommons.org/licenses/by/2.0/legalcode"
+	},
+	"CC-BY-2.5": {
+		"name": "Creative Commons Attribution 2.5",
+		"url": "http://creativecommons.org/licenses/by/2.5/legalcode"
+	},
+	"CC-BY-3.0": {
+		"name": "Creative Commons Attribution 3.0",
+		"url": "http://creativecommons.org/licenses/by/3.0/legalcode"
+	},
+	"CC-BY-4.0": {
+		"name": "Creative Commons Attribution 4.0",
+		"url": "http://creativecommons.org/licenses/by/4.0/legalcode"
+	},
+	"CC-BY-NC-1.0": {
+		"name": "Creative Commons Attribution Non Commercial 1.0",
+		"url": "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
+	},
+	"CC-BY-NC-2.0": {
+		"name": "Creative Commons Attribution Non Commercial 2.0",
+		"url": "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
+	},
+	"CC-BY-NC-2.5": {
+		"name": "Creative Commons Attribution Non Commercial 2.5",
+		"url": "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
+	},
+	"CC-BY-NC-3.0": {
+		"name": "Creative Commons Attribution Non Commercial 3.0",
+		"url": "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
+	},
+	"CC-BY-NC-4.0": {
+		"name": "Creative Commons Attribution Non Commercial 4.0",
+		"url": "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
+	},
+	"CC-BY-NC-ND-1.0": {
+		"name": "Creative Commons Attribution Non Commercial No Derivatives 1.0",
+		"url": "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+	},
+	"CC-BY-NC-ND-2.0": {
+		"name": "Creative Commons Attribution Non Commercial No Derivatives 2.0",
+		"url": "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+	},
+	"CC-BY-NC-ND-2.5": {
+		"name": "Creative Commons Attribution Non Commercial No Derivatives 2.5",
+		"url": "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+	},
+	"CC-BY-NC-ND-3.0": {
+		"name": "Creative Commons Attribution Non Commercial No Derivatives 3.0",
+		"url": "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+	},
+	"CC-BY-NC-ND-4.0": {
+		"name": "Creative Commons Attribution Non Commercial No Derivatives 4.0",
+		"url": "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+	},
+	"CC-BY-NC-SA-1.0": {
+		"name": "Creative Commons Attribution Non Commercial Share Alike 1.0",
+		"url": "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+	},
+	"CC-BY-NC-SA-2.0": {
+		"name": "Creative Commons Attribution Non Commercial Share Alike 2.0",
+		"url": "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+	},
+	"CC-BY-NC-SA-2.5": {
+		"name": "Creative Commons Attribution Non Commercial Share Alike 2.5",
+		"url": "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+	},
+	"CC-BY-NC-SA-3.0": {
+		"name": "Creative Commons Attribution Non Commercial Share Alike 3.0",
+		"url": "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+	},
+	"CC-BY-NC-SA-4.0": {
+		"name": "Creative Commons Attribution Non Commercial Share Alike 4.0",
+		"url": "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+	},
+	"CC-BY-ND-1.0": {
+		"name": "Creative Commons Attribution No Derivatives 1.0",
+		"url": "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
+	},
+	"CC-BY-ND-2.0": {
+		"name": "Creative Commons Attribution No Derivatives 2.0",
+		"url": "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+	},
+	"CC-BY-ND-2.5": {
+		"name": "Creative Commons Attribution No Derivatives 2.5",
+		"url": "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
+	},
+	"CC-BY-ND-3.0": {
+		"name": "Creative Commons Attribution No Derivatives 3.0",
+		"url": "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
+	},
+	"CC-BY-ND-4.0": {
+		"name": "Creative Commons Attribution No Derivatives 4.0",
+		"url": "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
+	},
+	"CC-BY-SA-1.0": {
+		"name": "Creative Commons Attribution Share Alike 1.0",
+		"url": "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
+	},
+	"CC-BY-SA-2.0": {
+		"name": "Creative Commons Attribution Share Alike 2.0",
+		"url": "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
+	},
+	"CC-BY-SA-2.5": {
+		"name": "Creative Commons Attribution Share Alike 2.5",
+		"url": "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
+	},
+	"CC-BY-SA-3.0": {
+		"name": "Creative Commons Attribution Share Alike 3.0",
+		"url": "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
+	},
+	"CC-BY-SA-4.0": {
+		"name": "Creative Commons Attribution Share Alike 4.0",
+		"url": "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
+	},
+	"CC0-1.0": {
+		"name": "Creative Commons Zero v1.0 Universal",
+		"url": "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+	},
+	"CDDL-1.0": {
+		"name": "Common Development and Distribution License 1.0",
+		"url": "http://www.opensource.org/licenses/cddl1"
+	},
+	"CDDL-1.1": {
+		"name": "Common Development and Distribution License 1.1",
+		"url": "http://glassfish.java.net/public/CDDL+GPL_1_1.html"
+	},
+	"CDLA-Permissive-1.0": {
+		"name": "Community Data License Agreement Permissive 1.0",
+		"url": "https://cdla.io/permissive-1-0"
+	},
+	"CDLA-Sharing-1.0": {
+		"name": "Community Data License Agreement Sharing 1.0",
+		"url": "https://cdla.io/sharing-1-0"
+	},
+	"CECILL-1.0": {
+		"name": "CeCILL Free Software License Agreement v1.0",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+	},
+	"CECILL-1.1": {
+		"name": "CeCILL Free Software License Agreement v1.1",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+	},
+	"CECILL-2.0": {
+		"name": "CeCILL Free Software License Agreement v2.0",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
+	},
+	"CECILL-2.1": {
+		"name": "CeCILL Free Software License Agreement v2.1",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
+	},
+	"CECILL-B": {
+		"name": "CeCILL-B Free Software License Agreement",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+	},
+	"CECILL-C": {
+		"name": "CeCILL-C Free Software License Agreement",
+		"url": "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html\n    "
+	},
+	"ClArtistic": {
+		"name": "Clarified Artistic License",
+		"url": "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/"
+	},
+	"CNRI-Jython": {
+		"name": "CNRI Jython License",
+		"url": "http://www.jython.org/license.html"
+	},
+	"CNRI-Python-GPL-Compatible": {
+		"name": "CNRI Python Open Source GPL Compatible License Agreement",
+		"url": "http://www.python.org/download/releases/1.6.1/download_win/"
+	},
+	"CNRI-Python": {
+		"name": "CNRI Python License",
+		"url": "http://www.opensource.org/licenses/CNRI-Python"
+	},
+	"Condor-1.1": {
+		"name": "Condor Public License v1.1",
+		"url": "http://research.cs.wisc.edu/condor/license.html#condor"
+	},
+	"CPAL-1.0": {
+		"name": "Common Public Attribution License 1.0",
+		"url": "http://www.opensource.org/licenses/CPAL-1.0"
+	},
+	"CPL-1.0": {
+		"name": "Common Public License 1.0",
+		"url": "http://opensource.org/licenses/CPL-1.0"
+	},
+	"CPOL-1.02": {
+		"name": "Code Project Open License 1.02",
+		"url": "http://www.codeproject.com/info/cpol10.aspx"
+	},
+	"Crossword": {
+		"name": "Crossword License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Crossword"
+	},
+	"CrystalStacker": {
+		"name": "CrystalStacker License",
+		"url": "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd=Licensing/CrystalStacker"
+	},
+	"CUA-OPL-1.0": {
+		"name": "CUA Office Public License v1.0",
+		"url": "http://opensource.org/licenses/CUA-OPL-1.0"
+	},
+	"Cube": {
+		"name": "Cube License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Cube"
+	},
+	"curl": {
+		"name": "curl License",
+		"url": "https://github.com/bagder/curl/blob/master/COPYING"
+	},
+	"D-FSL-1.0": {
+		"name": "Deutsche Freie Software Lizenz",
+		"url": "http://www.dipp.nrw.de/d-fsl/lizenzen/"
+	},
+	"diffmark": {
+		"name": "diffmark license",
+		"url": "https://fedoraproject.org/wiki/Licensing/diffmark"
+	},
+	"DOC": {
+		"name": "DOC License",
+		"url": "http://www.cs.wustl.edu/~schmidt/ACE-copying.html"
+	},
+	"Dotseqn": {
+		"name": "Dotseqn License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+	},
+	"DSDP": {
+		"name": "DSDP License",
+		"url": "https://fedoraproject.org/wiki/Licensing/DSDP"
+	},
+	"dvipdfm": {
+		"name": "dvipdfm License",
+		"url": "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+	},
+	"ECL-1.0": {
+		"name": "Educational Community License v1.0",
+		"url": "http://opensource.org/licenses/ECL-1.0"
+	},
+	"ECL-2.0": {
+		"name": "Educational Community License v2.0",
+		"url": "http://opensource.org/licenses/ECL-2.0"
+	},
+	"EFL-1.0": {
+		"name": "Eiffel Forum License v1.0",
+		"url": "http://www.eiffel-nice.org/license/forum.txt"
+	},
+	"EFL-2.0": {
+		"name": "Eiffel Forum License v2.0",
+		"url": "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html"
+	},
+	"eGenix": {
+		"name": "eGenix.com Public License 1.1.0",
+		"url": "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf"
+	},
+	"Entessa": {
+		"name": "Entessa Public License v1.0",
+		"url": "http://opensource.org/licenses/Entessa"
+	},
+	"EPL-1.0": {
+		"name": "Eclipse Public License 1.0",
+		"url": "http://www.eclipse.org/legal/epl-v10.html"
+	},
+	"EPL-2.0": {
+		"name": "Eclipse Public License 2.0",
+		"url": "https://www.eclipse.org/legal/epl-2.0"
+	},
+	"ErlPL-1.1": {
+		"name": "Erlang Public License v1.1",
+		"url": "http://www.erlang.org/EPLICENSE"
+	},
+	"EUDatagrid": {
+		"name": "EU DataGrid Software License",
+		"url": "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html"
+	},
+	"EUPL-1.0": {
+		"name": "European Union Public License 1.0",
+		"url": "http://ec.europa.eu/idabc/en/document/7330.html"
+	},
+	"EUPL-1.1": {
+		"name": "European Union Public License 1.1",
+		"url": "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl"
+	},
+	"EUPL-1.2": {
+		"name": "European Union Public License 1.2",
+		"url": "https://joinup.ec.europa.eu/page/eupl-text-11-12"
+	},
+	"Eurosym": {
+		"name": "Eurosym License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Eurosym"
+	},
+	"Fair": {
+		"name": "Fair License",
+		"url": "http://www.opensource.org/licenses/Fair"
+	},
+	"Frameworx-1.0": {
+		"name": "Frameworx Open License 1.0",
+		"url": "http://www.opensource.org/licenses/Frameworx-1.0"
+	},
+	"FreeImage": {
+		"name": "FreeImage Public License v1.0",
+		"url": "http://freeimage.sourceforge.net/freeimage-license.txt"
+	},
+	"FSFAP": {
+		"name": "FSF All Permissive License",
+		"url": "http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+	},
+	"FSFUL": {
+		"name": "FSF Unlimited License",
+		"url": "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+	},
+	"FSFULLR": {
+		"name": "FSF Unlimited License (with License Retention)",
+		"url": "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+	},
+	"FTL": {
+		"name": "Freetype Project License",
+		"url": "http://freetype.fis.uniroma2.it/FTL.TXT"
+	},
+	"GFDL-1.1-only": {
+		"name": "GNU Free Documentation License v1.1 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+	},
+	"GFDL-1.1-or-later": {
+		"name": "GNU Free Documentation License v1.1 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+	},
+	"GFDL-1.2-only": {
+		"name": "GNU Free Documentation License v1.2 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+	},
+	"GFDL-1.2-or-later": {
+		"name": "GNU Free Documentation License v1.2 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+	},
+	"GFDL-1.3-only": {
+		"name": "GNU Free Documentation License v1.3 only",
+		"url": "http://www.gnu.org/licenses/fdl-1.3.txt"
+	},
+	"GFDL-1.3-or-later": {
+		"name": "GNU Free Documentation License v1.3 or later",
+		"url": "http://www.gnu.org/licenses/fdl-1.3.txt"
+	},
+	"Giftware": {
+		"name": "Giftware License",
+		"url": "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+	},
+	"GL2PS": {
+		"name": "GL2PS License",
+		"url": "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+	},
+	"Glide": {
+		"name": "3dfx Glide License",
+		"url": "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
+	},
+	"Glulxe": {
+		"name": "Glulxe License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Glulxe"
+	},
+	"gnuplot": {
+		"name": "gnuplot License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+	},
+	"GPL-1.0-only": {
+		"name": "GNU General Public License v1.0 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+	},
+	"GPL-1.0-or-later": {
+		"name": "GNU General Public License v1.0 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+	},
+	"GPL-2.0-only": {
+		"name": "GNU General Public License v2.0 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
+	},
+	"GPL-2.0-or-later": {
+		"name": "GNU General Public License v2.0 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
+	},
+	"GPL-3.0-only": {
+		"name": "GNU General Public License v3.0 only",
+		"url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html"
+	},
+	"GPL-3.0-or-later": {
+		"name": "GNU General Public License v3.0 or later",
+		"url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html"
+	},
+	"gSOAP-1.3b": {
+		"name": "gSOAP Public License v1.3b",
+		"url": "http://www.cs.fsu.edu/~engelen/license.html"
+	},
+	"HaskellReport": {
+		"name": "Haskell Language Report License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
+	},
+	"HPND": {
+		"name": "Historical Permission Notice and Disclaimer",
+		"url": "http://www.opensource.org/licenses/HPND"
+	},
+	"IBM-pibs": {
+		"name": "IBM PowerPC Initialization and Boot Software",
+		"url": "http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d"
+	},
+	"ICU": {
+		"name": "ICU License",
+		"url": "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+	},
+	"IJG": {
+		"name": "Independent JPEG Group License",
+		"url": "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev=1.2"
+	},
+	"ImageMagick": {
+		"name": "ImageMagick License",
+		"url": "http://www.imagemagick.org/script/license.php"
+	},
+	"iMatix": {
+		"name": "iMatix Standard Function Library Agreement",
+		"url": "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+	},
+	"Imlib2": {
+		"name": "Imlib2 License",
+		"url": "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+	},
+	"Info-ZIP": {
+		"name": "Info-ZIP License",
+		"url": "http://www.info-zip.org/license.html"
+	},
+	"Intel-ACPI": {
+		"name": "Intel ACPI Software License Agreement",
+		"url": "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+	},
+	"Intel": {
+		"name": "Intel Open Source License",
+		"url": "http://opensource.org/licenses/Intel"
+	},
+	"Interbase-1.0": {
+		"name": "Interbase Public License v1.0",
+		"url": "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+	},
+	"IPA": {
+		"name": "IPA Font License",
+		"url": "http://www.opensource.org/licenses/IPA"
+	},
+	"IPL-1.0": {
+		"name": "IBM Public License v1.0",
+		"url": "http://www.opensource.org/licenses/IPL-1.0"
+	},
+	"ISC": {
+		"name": "ISC License",
+		"url": "https://www.isc.org/downloads/software-support-policy/isc-license/"
+	},
+	"JasPer-2.0": {
+		"name": "JasPer License",
+		"url": "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+	},
+	"JSON": {
+		"name": "JSON License",
+		"url": "http://www.json.org/license.html"
+	},
+	"LAL-1.2": {
+		"name": "Licence Art Libre 1.2",
+		"url": "http://artlibre.org/licence/lal/licence-art-libre-12/"
+	},
+	"LAL-1.3": {
+		"name": "Licence Art Libre 1.3",
+		"url": "http://artlibre.org/"
+	},
+	"Latex2e": {
+		"name": "Latex2e License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Latex2e"
+	},
+	"Leptonica": {
+		"name": "Leptonica License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Leptonica"
+	},
+	"LGPL-2.0-only": {
+		"name": "GNU Library General Public License v2 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+	},
+	"LGPL-2.0-or-later": {
+		"name": "GNU Library General Public License v2 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+	},
+	"LGPL-2.1-only": {
+		"name": "GNU Lesser General Public License v2.1 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+	},
+	"LGPL-2.1-or-later": {
+		"name": "GNU Lesser General Public License v2.1 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+	},
+	"LGPL-3.0-only": {
+		"name": "GNU Lesser General Public License v3.0 only",
+		"url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+	},
+	"LGPL-3.0-or-later": {
+		"name": "GNU Lesser General Public License v3.0 or later",
+		"url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+	},
+	"LGPLLR": {
+		"name": "Lesser General Public License For Linguistic Resources",
+		"url": "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+	},
+	"Libpng": {
+		"name": "libpng License",
+		"url": "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+	},
+	"libtiff": {
+		"name": "libtiff License",
+		"url": "https://fedoraproject.org/wiki/Licensing/libtiff"
+	},
+	"LiLiQ-P-1.1": {
+		"name": "Licence Libre du Québec – Permissive version 1.1",
+		"url": "http://opensource.org/licenses/LiLiQ-P-1.1"
+	},
+	"LiLiQ-R-1.1": {
+		"name": "Licence Libre du Québec – Réciprocité version 1.1",
+		"url": "http://opensource.org/licenses/LiLiQ-R-1.1"
+	},
+	"LiLiQ-Rplus-1.1": {
+		"name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+		"url": "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+	},
+	"LPL-1.0": {
+		"name": "Lucent Public License Version 1.0",
+		"url": "http://opensource.org/licenses/LPL-1.0"
+	},
+	"LPL-1.02": {
+		"name": "Lucent Public License v1.02",
+		"url": "http://plan9.bell-labs.com/plan9/license.html"
+	},
+	"LPPL-1.0": {
+		"name": "LaTeX Project Public License v1.0",
+		"url": "http://www.latex-project.org/lppl/lppl-1-0.txt"
+	},
+	"LPPL-1.1": {
+		"name": "LaTeX Project Public License v1.1",
+		"url": "http://www.latex-project.org/lppl/lppl-1-1.txt"
+	},
+	"LPPL-1.2": {
+		"name": "LaTeX Project Public License v1.2",
+		"url": "http://www.latex-project.org/lppl/lppl-1-2.txt"
+	},
+	"LPPL-1.3a": {
+		"name": "LaTeX Project Public License v1.3a",
+		"url": "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+	},
+	"LPPL-1.3c": {
+		"name": "LaTeX Project Public License v1.3c",
+		"url": "http://www.latex-project.org/lppl/lppl-1-3c.txt"
+	},
+	"MakeIndex": {
+		"name": "MakeIndex License",
+		"url": "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+	},
+	"MirOS": {
+		"name": "MirOS License",
+		"url": "http://www.opensource.org/licenses/MirOS"
+	},
+	"MIT-advertising": {
+		"name": "Enlightenment License (e16)",
+		"url": "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+	},
+	"MIT-CMU": {
+		"name": "CMU License",
+		"url": "https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style"
+	},
+	"MIT-enna": {
+		"name": "enna License",
+		"url": "https://fedoraproject.org/wiki/Licensing/MIT#enna"
+	},
+	"MIT-feh": {
+		"name": "feh License",
+		"url": "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+	},
+	"MIT": {
+		"name": "MIT License",
+		"url": "http://www.opensource.org/licenses/MIT"
+	},
+	"MITNFA": {
+		"name": "MIT +no-false-attribs license",
+		"url": "https://fedoraproject.org/wiki/Licensing/MITNFA"
+	},
+	"Motosoto": {
+		"name": "Motosoto License",
+		"url": "http://www.opensource.org/licenses/Motosoto"
+	},
+	"mpich2": {
+		"name": "mpich2 License",
+		"url": "https://fedoraproject.org/wiki/Licensing/MIT"
+	},
+	"MPL-1.0": {
+		"name": "Mozilla Public License 1.0",
+		"url": "http://www.mozilla.org/MPL/MPL-1.0.html"
+	},
+	"MPL-1.1": {
+		"name": "Mozilla Public License 1.1",
+		"url": "http://www.mozilla.org/MPL/MPL-1.1.html"
+	},
+	"MPL-2.0-no-copyleft-exception": {
+		"name": "Mozilla Public License 2.0 (no copyleft exception)",
+		"url": "http://www.mozilla.org/MPL/2.0/"
+	},
+	"MPL-2.0": {
+		"name": "Mozilla Public License 2.0",
+		"url": "http://www.mozilla.org/MPL/2.0/"
+	},
+	"MS-PL": {
+		"name": "Microsoft Public License",
+		"url": "http://www.microsoft.com/opensource/licenses.mspx"
+	},
+	"MS-RL": {
+		"name": "Microsoft Reciprocal License",
+		"url": "http://www.microsoft.com/opensource/licenses.mspx"
+	},
+	"MTLL": {
+		"name": "Matrix Template Library License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+	},
+	"Multics": {
+		"name": "Multics License",
+		"url": "http://www.opensource.org/licenses/Multics"
+	},
+	"Mup": {
+		"name": "Mup License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Mup"
+	},
+	"NASA-1.3": {
+		"name": "NASA Open Source Agreement 1.3",
+		"url": "http://ti.arc.nasa.gov/opensource/nosa/"
+	},
+	"Naumen": {
+		"name": "Naumen Public License",
+		"url": "http://www.opensource.org/licenses/Naumen"
+	},
+	"NBPL-1.0": {
+		"name": "Net Boolean Public License v1",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+	},
+	"NCSA": {
+		"name": "University of Illinois/NCSA Open Source License",
+		"url": "http://otm.illinois.edu/uiuc_openSource"
+	},
+	"Net-SNMP": {
+		"name": "Net-SNMP License",
+		"url": "http://net-snmp.sourceforge.net/about/license.html"
+	},
+	"NetCDF": {
+		"name": "NetCDF license",
+		"url": "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+	},
+	"Newsletr": {
+		"name": "Newsletr License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Newsletr"
+	},
+	"NGPL": {
+		"name": "Nethack General Public License",
+		"url": "http://www.opensource.org/licenses/NGPL"
+	},
+	"NLOD-1.0": {
+		"name": "Norwegian Licence for Open Government Data",
+		"url": "http://data.norge.no/nlod/en/1.0"
+	},
+	"NLPL": {
+		"name": "No Limit Public License",
+		"url": "https://fedoraproject.org/wiki/Licensing/NLPL"
+	},
+	"Nokia": {
+		"name": "Nokia Open Source License",
+		"url": "http://www.opensource.org/licenses/nokia"
+	},
+	"NOSL": {
+		"name": "Netizen Open Source License",
+		"url": "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+	},
+	"Noweb": {
+		"name": "Noweb License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Noweb"
+	},
+	"NPL-1.0": {
+		"name": "Netscape Public License v1.0",
+		"url": "http://www.mozilla.org/MPL/NPL/1.0/"
+	},
+	"NPL-1.1": {
+		"name": "Netscape Public License v1.1",
+		"url": "http://www.mozilla.org/MPL/NPL/1.1/"
+	},
+	"NPOSL-3.0": {
+		"name": "Non-Profit Open Software License 3.0",
+		"url": "http://www.opensource.org/licenses/NOSL3.0"
+	},
+	"NRL": {
+		"name": "NRL License",
+		"url": "http://web.mit.edu/network/isakmp/nrllicense.html"
+	},
+	"NTP": {
+		"name": "NTP License",
+		"url": "http://www.opensource.org/licenses/NTP"
+	},
+	"OCCT-PL": {
+		"name": "Open CASCADE Technology Public License",
+		"url": "http://www.opencascade.com/content/occt-public-license"
+	},
+	"OCLC-2.0": {
+		"name": "OCLC Research Public License 2.0",
+		"url": "http://www.oclc.org/research/activities/software/license/v2final.htm"
+	},
+	"ODbL-1.0": {
+		"name": "ODC Open Database License v1.0",
+		"url": "http://www.opendatacommons.org/licenses/odbl/1.0/"
+	},
+	"OFL-1.0": {
+		"name": "SIL Open Font License 1.0",
+		"url": "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
+	},
+	"OFL-1.1": {
+		"name": "SIL Open Font License 1.1",
+		"url": "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web"
+	},
+	"OGTSL": {
+		"name": "Open Group Test Suite License",
+		"url": "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt"
+	},
+	"OLDAP-1.1": {
+		"name": "Open LDAP Public License v1.1",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=806557a5ad59804ef3a44d5abfbe91d706b0791f"
+	},
+	"OLDAP-1.2": {
+		"name": "Open LDAP Public License v1.2",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=42b0383c50c299977b5893ee695cf4e486fb0dc7"
+	},
+	"OLDAP-1.3": {
+		"name": "Open LDAP Public License v1.3",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=e5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+	},
+	"OLDAP-1.4": {
+		"name": "Open LDAP Public License v1.4",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=c9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+	},
+	"OLDAP-2.0.1": {
+		"name": "Open LDAP Public License v2.0.1",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b6d68acd14e51ca3aab4428bf26522aa74873f0e"
+	},
+	"OLDAP-2.0": {
+		"name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+	},
+	"OLDAP-2.1": {
+		"name": "Open LDAP Public License v2.1",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b0d176738e96a0d3b9f85cb51e140a86f21be715"
+	},
+	"OLDAP-2.2.1": {
+		"name": "Open LDAP Public License v2.2.1",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=4bc786f34b50aa301be6f5600f58a980070f481e"
+	},
+	"OLDAP-2.2.2": {
+		"name": "Open LDAP Public License 2.2.2",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=df2cc1e21eb7c160695f5b7cffd6296c151ba188"
+	},
+	"OLDAP-2.2": {
+		"name": "Open LDAP Public License v2.2",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=470b0c18ec67621c85881b2733057fecf4a1acc3"
+	},
+	"OLDAP-2.3": {
+		"name": "Open LDAP Public License v2.3",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=d32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+	},
+	"OLDAP-2.4": {
+		"name": "Open LDAP Public License v2.4",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cd1284c4a91a8a380d904eee68d1583f989ed386"
+	},
+	"OLDAP-2.5": {
+		"name": "Open LDAP Public License v2.5",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=6852b9d90022e8593c98205413380536b1b5a7cf"
+	},
+	"OLDAP-2.6": {
+		"name": "Open LDAP Public License v2.6",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=1cae062821881f41b73012ba816434897abf4205"
+	},
+	"OLDAP-2.7": {
+		"name": "Open LDAP Public License v2.7",
+		"url": "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=47c2415c1df81556eeb39be6cad458ef87c534a2"
+	},
+	"OLDAP-2.8": {
+		"name": "Open LDAP Public License v2.8",
+		"url": "http://www.openldap.org/software/release/license.html"
+	},
+	"OML": {
+		"name": "Open Market License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+	},
+	"OpenSSL": {
+		"name": "OpenSSL License",
+		"url": "http://www.openssl.org/source/license.html"
+	},
+	"OPL-1.0": {
+		"name": "Open Public License v1.0",
+		"url": "http://old.koalateam.com/jackaroo/OPL_1_0.TXT"
+	},
+	"OSET-PL-2.1": {
+		"name": "OSET Public License version 2.1",
+		"url": "http://opensource.org/licenses/OPL-2.1"
+	},
+	"OSL-1.0": {
+		"name": "Open Software License 1.0",
+		"url": "http://opensource.org/licenses/OSL-1.0"
+	},
+	"OSL-1.1": {
+		"name": "Open Software License 1.1",
+		"url": "https://fedoraproject.org/wiki/Licensing/OSL1.1"
+	},
+	"OSL-2.0": {
+		"name": "Open Software License 2.0",
+		"url": "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
+	},
+	"OSL-2.1": {
+		"name": "Open Software License 2.1",
+		"url": "http://opensource.org/licenses/OSL-2.1"
+	},
+	"OSL-3.0": {
+		"name": "Open Software License 3.0",
+		"url": "http://www.rosenlaw.com/OSL3.0.htm"
+	},
+	"PDDL-1.0": {
+		"name": "ODC Public Domain Dedication & License 1.0",
+		"url": "http://opendatacommons.org/licenses/pddl/1.0/"
+	},
+	"PHP-3.0": {
+		"name": "PHP License v3.0",
+		"url": "http://www.opensource.org/licenses/PHP-3.0"
+	},
+	"PHP-3.01": {
+		"name": "PHP License v3.01",
+		"url": "http://www.php.net/license/3_01.txt"
+	},
+	"Plexus": {
+		"name": "Plexus Classworlds License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+	},
+	"PostgreSQL": {
+		"name": "PostgreSQL License",
+		"url": "http://www.postgresql.org/about/licence"
+	},
+	"psfrag": {
+		"name": "psfrag License",
+		"url": "https://fedoraproject.org/wiki/Licensing/psfrag"
+	},
+	"psutils": {
+		"name": "psutils License",
+		"url": "https://fedoraproject.org/wiki/Licensing/psutils"
+	},
+	"Python-2.0": {
+		"name": "Python License 2.0",
+		"url": "http://www.opensource.org/licenses/Python-2.0"
+	},
+	"Qhull": {
+		"name": "Qhull License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Qhull"
+	},
+	"QPL-1.0": {
+		"name": "Q Public License 1.0",
+		"url": "http://doc.qt.nokia.com/3.3/license.html"
+	},
+	"Rdisc": {
+		"name": "Rdisc License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+	},
+	"RHeCos-1.1": {
+		"name": "Red Hat eCos Public License v1.1",
+		"url": "http://ecos.sourceware.org/old-license.html"
+	},
+	"RPL-1.1": {
+		"name": "Reciprocal Public License 1.1",
+		"url": "http://opensource.org/licenses/RPL-1.1"
+	},
+	"RPL-1.5": {
+		"name": "Reciprocal Public License 1.5",
+		"url": "http://www.opensource.org/licenses/RPL-1.5"
+	},
+	"RPSL-1.0": {
+		"name": "RealNetworks Public Source License v1.0",
+		"url": "https://helixcommunity.org/content/rpsl"
+	},
+	"RSA-MD": {
+		"name": "RSA Message-Digest License ",
+		"url": "http://www.faqs.org/rfcs/rfc1321.html"
+	},
+	"RSCPL": {
+		"name": "Ricoh Source Code Public License",
+		"url": "http://www.opensource.org/licenses/RSCPL"
+	},
+	"Ruby": {
+		"name": "Ruby License",
+		"url": "http://www.ruby-lang.org/en/LICENSE.txt"
+	},
+	"SAX-PD": {
+		"name": "Sax Public Domain Notice",
+		"url": "http://www.saxproject.org/copying.html"
+	},
+	"Saxpath": {
+		"name": "Saxpath License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+	},
+	"SCEA": {
+		"name": "SCEA Shared Source License",
+		"url": "http://research.scea.com/scea_shared_source_license.html"
+	},
+	"Sendmail": {
+		"name": "Sendmail License",
+		"url": "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+	},
+	"SGI-B-1.0": {
+		"name": "SGI Free Software License B v1.0",
+		"url": "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+	},
+	"SGI-B-1.1": {
+		"name": "SGI Free Software License B v1.1",
+		"url": "http://oss.sgi.com/projects/FreeB/"
+	},
+	"SGI-B-2.0": {
+		"name": "SGI Free Software License B v2.0",
+		"url": "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+	},
+	"SimPL-2.0": {
+		"name": "Simple Public License 2.0",
+		"url": "http://www.opensource.org/licenses/SimPL-2.0"
+	},
+	"SISSL-1.2": {
+		"name": "Sun Industry Standards Source License v1.2",
+		"url": "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+	},
+	"SISSL": {
+		"name": "Sun Industry Standards Source License v1.1",
+		"url": "http://www.openoffice.org/licenses/sissl_license.html"
+	},
+	"Sleepycat": {
+		"name": "Sleepycat License",
+		"url": "http://www.opensource.org/licenses/Sleepycat"
+	},
+	"SMLNJ": {
+		"name": "Standard ML of New Jersey License",
+		"url": "https://www.smlnj.org/license.html"
+	},
+	"SMPPL": {
+		"name": "Secure Messaging Protocol Public License",
+		"url": "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+	},
+	"SNIA": {
+		"name": "SNIA Public License 1.1",
+		"url": "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+	},
+	"Spencer-86": {
+		"name": "Spencer License 86",
+		"url": "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+	},
+	"Spencer-94": {
+		"name": "Spencer License 94",
+		"url": "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+	},
+	"Spencer-99": {
+		"name": "Spencer License 99",
+		"url": "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+	},
+	"SPL-1.0": {
+		"name": "Sun Public License v1.0",
+		"url": "http://www.opensource.org/licenses/SPL-1.0"
+	},
+	"SugarCRM-1.1.3": {
+		"name": "SugarCRM Public License v1.1.3",
+		"url": "http://www.sugarcrm.com/crm/SPL"
+	},
+	"SWL": {
+		"name": "Scheme Widget Library (SWL) Software License Agreement",
+		"url": "https://fedoraproject.org/wiki/Licensing/SWL"
+	},
+	"TCL": {
+		"name": "TCL/TK License",
+		"url": "http://www.tcl.tk/software/tcltk/license.html"
+	},
+	"TCP-wrappers": {
+		"name": "TCP Wrappers License",
+		"url": "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+	},
+	"TMate": {
+		"name": "TMate Open Source License",
+		"url": "http://svnkit.com/license.html"
+	},
+	"TORQUE-1.1": {
+		"name": "TORQUE v2.5+ Software License v1.1",
+		"url": "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+	},
+	"TOSL": {
+		"name": "Trusster Open Source License",
+		"url": "https://fedoraproject.org/wiki/Licensing/TOSL"
+	},
+	"Unicode-DFS-2015": {
+		"name": "Unicode License Agreement - Data Files and Software (2015)",
+		"url": "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+	},
+	"Unicode-DFS-2016": {
+		"name": "Unicode License Agreement - Data Files and Software (2016)",
+		"url": "http://www.unicode.org/copyright.html"
+	},
+	"Unicode-TOU": {
+		"name": "Unicode Terms of Use",
+		"url": "http://www.unicode.org/copyright.html"
+	},
+	"Unlicense": {
+		"name": "The Unlicense",
+		"url": "http://unlicense.org/"
+	},
+	"UPL-1.0": {
+		"name": "Universal Permissive License v1.0",
+		"url": "http://opensource.org/licenses/UPL"
+	},
+	"Vim": {
+		"name": "Vim License",
+		"url": "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+	},
+	"VOSTROM": {
+		"name": "VOSTROM Public License for Open Source",
+		"url": "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+	},
+	"VSL-1.0": {
+		"name": "Vovida Software License v1.0",
+		"url": "http://www.opensource.org/licenses/VSL-1.0"
+	},
+	"W3C-19980720": {
+		"name": "W3C Software Notice and License (1998-07-20)",
+		"url": "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+	},
+	"W3C-20150513": {
+		"name": "W3C Software Notice and Document License (2015-05-13)",
+		"url": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+	},
+	"W3C": {
+		"name": "W3C Software Notice and License (2002-12-31)",
+		"url": "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html"
+	},
+	"Watcom-1.0": {
+		"name": "Sybase Open Watcom Public License 1.0",
+		"url": "http://www.opensource.org/licenses/Watcom-1.0"
+	},
+	"Wsuipa": {
+		"name": "Wsuipa License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+	},
+	"WTFPL": {
+		"name": "Do What The F*ck You Want To Public License",
+		"url": "http://sam.zoy.org/wtfpl/COPYING"
+	},
+	"X11": {
+		"name": "X11 License",
+		"url": "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+	},
+	"Xerox": {
+		"name": "Xerox License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Xerox"
+	},
+	"XFree86-1.1": {
+		"name": "XFree86 License 1.1",
+		"url": "http://www.xfree86.org/current/LICENSE4.html"
+	},
+	"xinetd": {
+		"name": "xinetd License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+	},
+	"Xnet": {
+		"name": "X.Net License",
+		"url": "http://opensource.org/licenses/Xnet"
+	},
+	"xpp": {
+		"name": "XPP License",
+		"url": "https://fedoraproject.org/wiki/Licensing/xpp"
+	},
+	"XSkat": {
+		"name": "XSkat License",
+		"url": "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+	},
+	"YPL-1.0": {
+		"name": "Yahoo! Public License v1.0",
+		"url": "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+	},
+	"YPL-1.1": {
+		"name": "Yahoo! Public License v1.1",
+		"url": "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+	},
+	"Zed": {
+		"name": "Zed License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Zed"
+	},
+	"Zend-2.0": {
+		"name": "Zend License v2.0",
+		"url": "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+	},
+	"Zimbra-1.3": {
+		"name": "Zimbra Public License v1.3",
+		"url": "https://spdx.org/licenses/Zimbra-1.3.html"
+	},
+	"Zimbra-1.4": {
+		"name": "Zimbra Public License v1.4",
+		"url": "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+	},
+	"zlib-acknowledgement": {
+		"name": "zlib/libpng License with Acknowledgement",
+		"url": "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
+	},
+	"Zlib": {
+		"name": "zlib License",
+		"url": "http://www.zlib.net/zlib_license.html"
+	},
+	"ZPL-1.1": {
+		"name": "Zope Public License 1.1",
+		"url": "http://old.zope.org/Resources/License/ZPL-1.1"
+	},
+	"ZPL-2.0": {
+		"name": "Zope Public License 2.0",
+		"url": "http://old.zope.org/Resources/License/ZPL-2.0"
+	},
+	"ZPL-2.1": {
+		"name": "Zope Public License 2.1",
+		"url": "http://old.zope.org/Resources/ZPL/"
+	},
+	"AGPL-3.0": {
+		"name": "GNU Affero General Public License v3.0",
+		"url": "http://www.gnu.org/licenses/agpl.txt"
+	},
+	"eCos-2.0": {
+		"name": "eCos license version 2.0",
+		"url": "http://www.gnu.org/licenses/ecos-license.html"
+	},
+	"GFDL-1.1": {
+		"name": "GNU Free Documentation License v1.1",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+	},
+	"GFDL-1.2": {
+		"name": "GNU Free Documentation License v1.2",
+		"url": "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+	},
+	"GFDL-1.3": {
+		"name": "GNU Free Documentation License v1.3",
+		"url": "http://www.gnu.org/licenses/fdl-1.3.txt"
+	},
+	"GPL-1.0+": {
+		"name": "GNU General Public License v1.0 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+	},
+	"GPL-1.0": {
+		"name": "GNU General Public License v1.0 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+	},
+	"GPL-2.0+": {
+		"name": "GNU General Public License v2.0 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
+	},
+	"GPL-2.0-with-autoconf-exception": {
+		"name": "GNU General Public License v2.0 w/Autoconf exception",
+		"url": "http://ac-archive.sourceforge.net/doc/copyright.html"
+	},
+	"GPL-2.0-with-bison-exception": {
+		"name": "GNU General Public License v2.0 w/Bison exception",
+		"url": "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141"
+	},
+	"GPL-2.0-with-classpath-exception": {
+		"name": "GNU General Public License v2.0 w/Classpath exception",
+		"url": "http://www.gnu.org/software/classpath/license.html"
+	},
+	"GPL-2.0-with-font-exception": {
+		"name": "GNU General Public License v2.0 w/Font exception",
+		"url": "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+	},
+	"GPL-2.0-with-GCC-exception": {
+		"name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+		"url": "https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+	},
+	"GPL-2.0": {
+		"name": "GNU General Public License v2.0 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
+	},
+	"GPL-3.0+": {
+		"name": "GNU General Public License v3.0 or later",
+		"url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html"
+	},
+	"GPL-3.0-with-autoconf-exception": {
+		"name": "GNU General Public License v3.0 w/Autoconf exception",
+		"url": "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+	},
+	"GPL-3.0-with-GCC-exception": {
+		"name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+		"url": "http://www.gnu.org/licenses/gcc-exception-3.1.html"
+	},
+	"GPL-3.0": {
+		"name": "GNU General Public License v3.0 only",
+		"url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html"
+	},
+	"LGPL-2.0+": {
+		"name": "GNU Library General Public License v2 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+	},
+	"LGPL-2.0": {
+		"name": "GNU Library General Public License v2 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+	},
+	"LGPL-2.1+": {
+		"name": "GNU Library General Public License v2 or later",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+	},
+	"LGPL-2.1": {
+		"name": "GNU Lesser General Public License v2.1 only",
+		"url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+	},
+	"LGPL-3.0+": {
+		"name": "GNU Lesser General Public License v3.0 or later",
+		"url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+	},
+	"LGPL-3.0": {
+		"name": "GNU Lesser General Public License v3.0 only",
+		"url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+	},
+	"Nunit": {
+		"name": "Nunit License",
+		"url": "https://fedoraproject.org/wiki/Licensing/Nunit"
+	},
+	"StandardML-NJ": {
+		"name": "Standard ML of New Jersey License",
+		"url": "http://www.smlnj.org//license.html"
+	},
+	"wxWindows": {
+		"name": "wxWindows Library License",
+		"url": "http://www.opensource.org/licenses/WXwindows"
+	}
+};


### PR DESCRIPTION
Fixes #131

Copied a full list of spdx licenses from https://github.com/sindresorhus/spdx-license-list/blob/master/spdx.json with the `osiApproved` metadata removed.